### PR TITLE
updating usability

### DIFF
--- a/BlackJackApplication/BlackJackApplication/Card.cs
+++ b/BlackJackApplication/BlackJackApplication/Card.cs
@@ -12,6 +12,7 @@ namespace BlackJackApplication
         private string cardValue;
         private string cardSuit;
         private Image cardImage;
+        private bool hidden;
 
         public Card(string suit, string value, Image image)
         {
@@ -34,6 +35,12 @@ namespace BlackJackApplication
         {
             get { return cardImage; }
             set { cardImage = value; }
+        }
+        
+        public bool Hidden
+        {
+            get { return hidden;}
+            set { hidden = value; }
         }
     }
 }

--- a/BlackJackApplication/BlackJackApplication/TableForm.Designer.cs
+++ b/BlackJackApplication/BlackJackApplication/TableForm.Designer.cs
@@ -45,23 +45,27 @@
             this.adjustMoneyTextBox = new System.Windows.Forms.TextBox();
             this.adjustMoneyButton = new System.Windows.Forms.Button();
             this.adjustMoneyStatusLabel = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(1141, 598);
+            this.label1.Location = new System.Drawing.Point(732, 80);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(105, 17);
+            this.label1.Size = new System.Drawing.Size(79, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Current Money:";
             // 
             // currentMoneyLabel
             // 
             this.currentMoneyLabel.AutoSize = true;
-            this.currentMoneyLabel.Location = new System.Drawing.Point(1241, 598);
+            this.currentMoneyLabel.Location = new System.Drawing.Point(826, 80);
+            this.currentMoneyLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.currentMoneyLabel.Name = "currentMoneyLabel";
-            this.currentMoneyLabel.Size = new System.Drawing.Size(0, 17);
+            this.currentMoneyLabel.Size = new System.Drawing.Size(0, 13);
             this.currentMoneyLabel.TabIndex = 1;
             // 
             // hitButton
@@ -72,14 +76,13 @@
             this.hitButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.hitButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.hitButton.ForeColor = System.Drawing.SystemColors.Control;
-            this.hitButton.Location = new System.Drawing.Point(1145, 260);
-            this.hitButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.hitButton.Location = new System.Drawing.Point(432, 330);
+            this.hitButton.Margin = new System.Windows.Forms.Padding(2);
             this.hitButton.Name = "hitButton";
-            this.hitButton.Size = new System.Drawing.Size(132, 48);
+            this.hitButton.Size = new System.Drawing.Size(99, 39);
             this.hitButton.TabIndex = 4;
             this.hitButton.Text = "Hit";
             this.hitButton.UseVisualStyleBackColor = false;
-            this.hitButton.EnabledChanged += new System.EventHandler(this.hitButton_EnabledChanged);
             this.hitButton.Click += new System.EventHandler(this.hitButton_Click);
             // 
             // standButton
@@ -88,67 +91,72 @@
             this.standButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.standButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.standButton.ForeColor = System.Drawing.SystemColors.Control;
-            this.standButton.Location = new System.Drawing.Point(1145, 335);
-            this.standButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.standButton.Location = new System.Drawing.Point(580, 330);
+            this.standButton.Margin = new System.Windows.Forms.Padding(2);
             this.standButton.Name = "standButton";
-            this.standButton.Size = new System.Drawing.Size(132, 48);
+            this.standButton.Size = new System.Drawing.Size(99, 39);
             this.standButton.TabIndex = 5;
             this.standButton.Text = "Stand";
             this.standButton.UseVisualStyleBackColor = false;
-            this.standButton.EnabledChanged += new System.EventHandler(this.standButton_EnabledChanged);
             this.standButton.Click += new System.EventHandler(this.standButton_Click);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(1141, 625);
+            this.label3.Location = new System.Drawing.Point(732, 182);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(84, 17);
+            this.label3.Size = new System.Drawing.Size(63, 13);
             this.label3.TabIndex = 13;
             this.label3.Text = "Current Bet:";
             // 
             // betLabel
             // 
             this.betLabel.AutoSize = true;
-            this.betLabel.Location = new System.Drawing.Point(1231, 625);
+            this.betLabel.Location = new System.Drawing.Point(807, 182);
+            this.betLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.betLabel.Name = "betLabel";
-            this.betLabel.Size = new System.Drawing.Size(24, 17);
+            this.betLabel.Size = new System.Drawing.Size(19, 13);
             this.betLabel.TabIndex = 14;
             this.betLabel.Text = "10";
             // 
             // dealerBetDescriptionLabel
             // 
             this.dealerBetDescriptionLabel.AutoSize = true;
-            this.dealerBetDescriptionLabel.Location = new System.Drawing.Point(557, 265);
+            this.dealerBetDescriptionLabel.Location = new System.Drawing.Point(43, 56);
+            this.dealerBetDescriptionLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.dealerBetDescriptionLabel.Name = "dealerBetDescriptionLabel";
-            this.dealerBetDescriptionLabel.Size = new System.Drawing.Size(140, 17);
+            this.dealerBetDescriptionLabel.Size = new System.Drawing.Size(104, 13);
             this.dealerBetDescriptionLabel.TabIndex = 15;
             this.dealerBetDescriptionLabel.Text = "Current Visible Total:";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(557, 538);
+            this.label5.Location = new System.Drawing.Point(474, 56);
+            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(95, 17);
+            this.label5.Size = new System.Drawing.Size(71, 13);
             this.label5.TabIndex = 16;
             this.label5.Text = "Current Total:";
             // 
             // dealerTotalLabel
             // 
             this.dealerTotalLabel.AutoSize = true;
-            this.dealerTotalLabel.Location = new System.Drawing.Point(713, 265);
+            this.dealerTotalLabel.Location = new System.Drawing.Point(168, 56);
+            this.dealerTotalLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.dealerTotalLabel.Name = "dealerTotalLabel";
-            this.dealerTotalLabel.Size = new System.Drawing.Size(16, 17);
+            this.dealerTotalLabel.Size = new System.Drawing.Size(13, 13);
             this.dealerTotalLabel.TabIndex = 17;
             this.dealerTotalLabel.Text = "0";
             // 
             // playerTotalLabel
             // 
             this.playerTotalLabel.AutoSize = true;
-            this.playerTotalLabel.Location = new System.Drawing.Point(713, 538);
+            this.playerTotalLabel.Location = new System.Drawing.Point(587, 56);
+            this.playerTotalLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.playerTotalLabel.Name = "playerTotalLabel";
-            this.playerTotalLabel.Size = new System.Drawing.Size(16, 17);
+            this.playerTotalLabel.Size = new System.Drawing.Size(13, 13);
             this.playerTotalLabel.TabIndex = 18;
             this.playerTotalLabel.Text = "0";
             // 
@@ -156,10 +164,9 @@
             // 
             this.endLabel.AutoSize = true;
             this.endLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 50F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.endLabel.Location = new System.Drawing.Point(175, 369);
-            this.endLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.endLabel.Location = new System.Drawing.Point(224, 313);
             this.endLabel.Name = "endLabel";
-            this.endLabel.Size = new System.Drawing.Size(0, 95);
+            this.endLabel.Size = new System.Drawing.Size(0, 76);
             this.endLabel.TabIndex = 22;
             this.endLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
@@ -169,14 +176,13 @@
             this.continueButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.continueButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.continueButton.ForeColor = System.Drawing.SystemColors.Control;
-            this.continueButton.Location = new System.Drawing.Point(1145, 410);
-            this.continueButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.continueButton.Location = new System.Drawing.Point(446, 412);
+            this.continueButton.Margin = new System.Windows.Forms.Padding(2);
             this.continueButton.Name = "continueButton";
-            this.continueButton.Size = new System.Drawing.Size(132, 48);
+            this.continueButton.Size = new System.Drawing.Size(99, 39);
             this.continueButton.TabIndex = 23;
-            this.continueButton.Text = "Continue";
+            this.continueButton.Text = "New Hand";
             this.continueButton.UseVisualStyleBackColor = false;
-            this.continueButton.EnabledChanged += new System.EventHandler(this.continueButton_EnabledChanged);
             this.continueButton.Click += new System.EventHandler(this.continueButton_Click);
             // 
             // lockBetButton
@@ -185,10 +191,10 @@
             this.lockBetButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.lockBetButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lockBetButton.ForeColor = System.Drawing.SystemColors.Control;
-            this.lockBetButton.Location = new System.Drawing.Point(1145, 485);
-            this.lockBetButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.lockBetButton.Location = new System.Drawing.Point(869, 209);
+            this.lockBetButton.Margin = new System.Windows.Forms.Padding(2);
             this.lockBetButton.Name = "lockBetButton";
-            this.lockBetButton.Size = new System.Drawing.Size(132, 48);
+            this.lockBetButton.Size = new System.Drawing.Size(135, 39);
             this.lockBetButton.TabIndex = 24;
             this.lockBetButton.Text = "Bet";
             this.lockBetButton.UseVisualStyleBackColor = false;
@@ -197,10 +203,9 @@
             // 
             // betTextBox
             // 
-            this.betTextBox.Location = new System.Drawing.Point(1145, 558);
-            this.betTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.betTextBox.Location = new System.Drawing.Point(869, 175);
             this.betTextBox.Name = "betTextBox";
-            this.betTextBox.Size = new System.Drawing.Size(131, 22);
+            this.betTextBox.Size = new System.Drawing.Size(135, 20);
             this.betTextBox.TabIndex = 25;
             this.betTextBox.Text = "Enter Bet: ";
             this.betTextBox.MouseClick += new System.Windows.Forms.MouseEventHandler(this.betTextBox_MouseClick);
@@ -208,12 +213,11 @@
             // 
             // adjustMoneyTextBox
             // 
-            this.adjustMoneyTextBox.Location = new System.Drawing.Point(15, 558);
-            this.adjustMoneyTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.adjustMoneyTextBox.Location = new System.Drawing.Point(868, 73);
             this.adjustMoneyTextBox.Name = "adjustMoneyTextBox";
-            this.adjustMoneyTextBox.Size = new System.Drawing.Size(168, 22);
+            this.adjustMoneyTextBox.Size = new System.Drawing.Size(136, 20);
             this.adjustMoneyTextBox.TabIndex = 27;
-            this.adjustMoneyTextBox.Text = "Enter Value: ";
+            this.adjustMoneyTextBox.Text = "Enter New Current Money: ";
             this.adjustMoneyTextBox.MouseClick += new System.Windows.Forms.MouseEventHandler(this.adjustMoneyTextBox_MouseClick);
             this.adjustMoneyTextBox.TextChanged += new System.EventHandler(this.adjustMoneyTextBox_TextChanged);
             // 
@@ -223,29 +227,54 @@
             this.adjustMoneyButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.adjustMoneyButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.adjustMoneyButton.ForeColor = System.Drawing.SystemColors.Control;
-            this.adjustMoneyButton.Location = new System.Drawing.Point(15, 485);
-            this.adjustMoneyButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.adjustMoneyButton.Location = new System.Drawing.Point(869, 100);
+            this.adjustMoneyButton.Margin = new System.Windows.Forms.Padding(2);
             this.adjustMoneyButton.Name = "adjustMoneyButton";
-            this.adjustMoneyButton.Size = new System.Drawing.Size(172, 48);
+            this.adjustMoneyButton.Size = new System.Drawing.Size(136, 54);
             this.adjustMoneyButton.TabIndex = 26;
-            this.adjustMoneyButton.Text = "Adjust Money";
+            this.adjustMoneyButton.Text = "Adjust Current Money";
             this.adjustMoneyButton.UseVisualStyleBackColor = false;
             this.adjustMoneyButton.Click += new System.EventHandler(this.adjustMoneyButton_Click);
             // 
             // adjustMoneyStatusLabel
             // 
             this.adjustMoneyStatusLabel.AutoSize = true;
-            this.adjustMoneyStatusLabel.Location = new System.Drawing.Point(15, 598);
+            this.adjustMoneyStatusLabel.Location = new System.Drawing.Point(815, 50);
+            this.adjustMoneyStatusLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.adjustMoneyStatusLabel.Name = "adjustMoneyStatusLabel";
-            this.adjustMoneyStatusLabel.Size = new System.Drawing.Size(0, 17);
+            this.adjustMoneyStatusLabel.Size = new System.Drawing.Size(0, 13);
             this.adjustMoneyStatusLabel.TabIndex = 28;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(62, 27);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(119, 20);
+            this.label2.TabIndex = 29;
+            this.label2.Text = "Dealer Cards:";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(485, 27);
+            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(115, 20);
+            this.label4.TabIndex = 30;
+            this.label4.Text = "Player Cards:";
             // 
             // tableForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(166)))), ((int)(((byte)(91)))));
-            this.ClientSize = new System.Drawing.Size(1332, 814);
+            this.ClientSize = new System.Drawing.Size(1015, 480);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label2);
             this.Controls.Add(this.adjustMoneyStatusLabel);
             this.Controls.Add(this.adjustMoneyTextBox);
             this.Controls.Add(this.adjustMoneyButton);
@@ -263,7 +292,7 @@
             this.Controls.Add(this.hitButton);
             this.Controls.Add(this.currentMoneyLabel);
             this.Controls.Add(this.label1);
-            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "tableForm";
             this.Text = "Blackjack";
             this.Load += new System.EventHandler(this.Form1_Load);
@@ -291,6 +320,8 @@
         internal System.Windows.Forms.TextBox adjustMoneyTextBox;
         internal System.Windows.Forms.Button adjustMoneyButton;
         private System.Windows.Forms.Label adjustMoneyStatusLabel;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label4;
     }
 }
 

--- a/BlackJackApplication/BlackJackApplication/TableForm.cs
+++ b/BlackJackApplication/BlackJackApplication/TableForm.cs
@@ -27,54 +27,19 @@ namespace BlackJackApplication
             Table table = new Table();
             turn = new Turn(this, myDeck, table, player1, dealer);
 
-            hitButton.Enabled = false;
-            standButton.Enabled = false;
-            continueButton.Enabled = false;
+            hitButton.Visible = false;
+            standButton.Visible = false;
+            continueButton.Visible = false;
             player1.AmountOfMoney = Int32.Parse(currentMoneyLabel.Text);
-        }
-
-        private void hitButton_EnabledChanged(object sender, EventArgs e)
-        {
-            if (hitButton.BackColor == Color.Gray)
-            {
-                hitButton.BackColor = Color.Crimson;
-            }
-            else
-            {
-                hitButton.BackColor = Color.Gray;
-            }
         }
         private void hitButton_Click(object sender, EventArgs e)
         { 
             turn.hitButtonClick();
         }
 
-        private void standButton_EnabledChanged(object sender, EventArgs e)
-        {
-            if (standButton.BackColor == Color.Gray)
-            {
-                standButton.BackColor = Color.FromArgb(6,67,157); //blue color
-            }
-            else
-            {
-                standButton.BackColor = Color.Gray;
-            }
-        }
         private void standButton_Click(object sender, EventArgs e)
         {
             turn.standButtonClick();
-        }
-
-        private void continueButton_EnabledChanged(object sender, EventArgs e)
-        {
-            if (continueButton.BackColor == Color.Gray)
-            {
-                continueButton.BackColor = Color.FromArgb(6, 67, 157); //blue color
-            }
-            else
-            {
-                continueButton.BackColor = Color.Gray;
-            }
         }
         private void continueButton_Click(object sender, EventArgs e)
         {
@@ -82,9 +47,9 @@ namespace BlackJackApplication
             {
                 endGame();
             }
-            this.continueButton.Enabled = false;
-            this.standButton.Enabled = true;
-            this.hitButton.Enabled = true;
+            this.continueButton.Visible = false;
+            this.standButton.Visible = true;
+            this.hitButton.Visible = true;
             turn.continueButtonClick();
         }
 
@@ -117,7 +82,7 @@ namespace BlackJackApplication
         {
             int number;
             bool betContainsOnlyDigits = Int32.TryParse(this.betTextBox.Text, out number);
-            if (betContainsOnlyDigits)
+            if (betContainsOnlyDigits || this.betTextBox.Text == "")
             {
                 betLabel.Text = betTextBox.Text;
             } else
@@ -134,6 +99,7 @@ namespace BlackJackApplication
             {
                 turn.adjustMoneyButtonClick();
             }
+            this.adjustMoneyTextBox.Text = "";
         }
 
         private void adjustMoneyTextBox_MouseClick(object sender, MouseEventArgs e)
@@ -150,13 +116,17 @@ namespace BlackJackApplication
         {
             int number;
             bool adjustMoneyContainsOnlyDigits = Int32.TryParse(this.adjustMoneyTextBox.Text, out number);
-            if (!adjustMoneyContainsOnlyDigits)
+            if (adjustMoneyContainsOnlyDigits)
             {
-                adjustMoneyStatusLabel.Text = "Not Valid";
+                adjustMoneyStatusLabel.Text = "Valid";
+            }
+            else if(this.adjustMoneyTextBox.Text == "")
+            {
+                adjustMoneyStatusLabel.Text = "";
             }
             else
             {
-                adjustMoneyStatusLabel.Text = "Valid";
+                adjustMoneyStatusLabel.Text = "Not Valid";
             }
         }
 

--- a/BlackJackApplication/BlackJackApplication/Turn.cs
+++ b/BlackJackApplication/BlackJackApplication/Turn.cs
@@ -15,10 +15,12 @@ namespace BlackJackApplication
         private Dealer turnDealer;
         private Deck turnDeck;
         tableForm turnForm = new tableForm();
-        const int IMAGE_STARTING_LOCATION_X = 192;
-        const int IMAGE_DISTANCE_X = 30;
-        const int PLAYER_IMAGE_Y = 500;
-        const int DEALER_IMAGE_Y = 15;
+        const int IMAGE_DISTANCE_Y = 20;
+        const int IMAGE_DISTANCE_X = 20;
+        const int PLAYER_IMAGE_Y = 75;
+        const int PLAYER_IMAGE_X = 470;
+        const int DEALER_IMAGE_Y = 75;
+        const int DEALER_IMAGE_X = 40;
 
 
         public Turn(tableForm currentForm = null, Deck deck = null, Table table = null, Player player = null, Dealer dealer = null)
@@ -30,7 +32,7 @@ namespace BlackJackApplication
             turnDeck = deck;
         }
 
-        // Handle adding images to the flowlayoutpanel depending on the user passed in
+        // Handle adding images to the table depending on the user passed in
         public void addImage(Image image, string player)
         {
             if (player == "player")
@@ -46,7 +48,7 @@ namespace BlackJackApplication
                             BackColor = Color.White,
                             SizeMode = PictureBoxSizeMode.StretchImage,
                             Size = new Size(120, 150),
-                            Location = new Point(IMAGE_STARTING_LOCATION_X + IMAGE_DISTANCE_X * cardNum, PLAYER_IMAGE_Y)
+                            Location = new Point(PLAYER_IMAGE_X + IMAGE_DISTANCE_X * cardNum, PLAYER_IMAGE_Y + IMAGE_DISTANCE_Y * cardNum)
                         };
                         turnForm.Controls.Add(pictureBox);
                         turnPlayer.PictureBoxes.Add(pictureBox);
@@ -60,13 +62,14 @@ namespace BlackJackApplication
                 {
                     if (turnDealer.currentPlayerHand[cardNum].CardImage == image)
                     {
+                        if (turnDealer.currentPlayerHand[cardNum].Hidden) { image = Properties.Resources.back; }
                         PictureBox pictureBox = new PictureBox()
                         {
                             Image = image,
                             BackColor = Color.White,
                             SizeMode = PictureBoxSizeMode.StretchImage,
                             Size = new Size(120, 150),
-                            Location = new Point(IMAGE_STARTING_LOCATION_X + IMAGE_DISTANCE_X * cardNum, DEALER_IMAGE_Y)
+                            Location = new Point(DEALER_IMAGE_X + IMAGE_DISTANCE_X * cardNum, DEALER_IMAGE_Y + IMAGE_DISTANCE_Y * cardNum)
                         };
                         turnForm.Controls.Add(pictureBox);
                         turnDealer.PictureBoxes.Add(pictureBox);
@@ -91,8 +94,8 @@ namespace BlackJackApplication
                     turnPlayer.AmountOfMoney = Convert.ToInt32(turnForm.currentMoneyLabel.Text);
                     turnForm.lockBetButton.Enabled = false;
                     turnForm.betTextBox.ReadOnly = true;
-                    turnForm.hitButton.Enabled = true;
-                    turnForm.standButton.Enabled = true;
+                    turnForm.hitButton.Visible = true;
+                    turnForm.standButton.Visible = true;
                     beginTurn();
                 } else
                 {
@@ -115,6 +118,7 @@ namespace BlackJackApplication
         {
             turnDealer.dealCard(turnPlayer, turnDeck, 2);
             turnDealer.dealCard(turnDealer, turnDeck, 2);
+            turnDealer.currentPlayerHand[0].Hidden = true;
 
             // Generate the hand for the player and dealer
             foreach (Card card in turnPlayer.currentPlayerHand)
@@ -122,9 +126,10 @@ namespace BlackJackApplication
                 addImage(card.CardImage, "player");
             }
 
-            // First card of dealers hand will be the back of the card
-            addImage(Properties.Resources.back, "dealer");
-            addImage(turnDealer.currentPlayerHand[turnDealer.currentPlayerHand.Count - 1].CardImage, "dealer");
+            foreach (Card card in turnDealer.currentPlayerHand)
+            {
+                addImage(card.CardImage, "dealer");
+            }
 
             // Set the intial values of the player and dealer total labels
             // First we have to validate the value of the hidden card in case it is a string
@@ -168,6 +173,10 @@ namespace BlackJackApplication
             if (turnPlayer.ValueOfHand > 21)
             {
                 playerBusts();
+            }
+            else if (turnPlayer.ValueOfHand == 21)
+            {
+                standButtonClick();
             }
         } 
 
@@ -219,8 +228,8 @@ namespace BlackJackApplication
             turnForm.dealerTotalLabel.Text = "";
             turnForm.playerTotalLabel.Text = "";
             turnDeck = new Deck();
-            turnForm.hitButton.Enabled = false;
-            turnForm.standButton.Enabled = false;
+            turnForm.hitButton.Visible = false;
+            turnForm.standButton.Visible = false;
             turnForm.lockBetButton.Enabled = true;
             turnForm.betTextBox.ReadOnly = false;
             foreach (PictureBox pictureBox in turnPlayer.PictureBoxes)
@@ -270,15 +279,16 @@ namespace BlackJackApplication
         public void endTurn()
         {
             // Show all of the cards the dealers hand actually contains at end of turn
+            turnDealer.currentPlayerHand[0].Hidden = false;
             foreach (Card card in turnDealer.currentPlayerHand)
             {
                 addImage(card.CardImage, "dealer");
             }
             turnForm.dealerBetDescriptionLabel.Text = "Current Total";
             turnForm.dealerTotalLabel.Text = turnDealer.ValueOfHand.ToString();
-            turnForm.hitButton.Enabled = false;
-            turnForm.standButton.Enabled = false;
-            turnForm.continueButton.Enabled = true;
+            turnForm.hitButton.Visible = false;
+            turnForm.standButton.Visible = false;
+            turnForm.continueButton.Visible = true;
             turnForm.currentMoneyLabel.Text = (turnPlayer.AmountOfMoney).ToString();
         }
     }


### PR DESCRIPTION
I added a "hidden" field to our cards so they can easily be turned on and off. The Adjust Money button matches the name of the display (“Adjust Current Money.”) Rather than “Enter value” it says “Enter new current money” I removed the feature that made the adjust money text box and bet text box say 'not valid' when nothing has been typed. I worked on the location of information and alignment and labeled the dealer/player cards. The “Continue” button now says “New Hand”. The back of the dealer card is now visible also. 